### PR TITLE
Always ask for the full 32-bytes sense buffer.

### DIFF
--- a/src/linux_sgio.pyx
+++ b/src/linux_sgio.pyx
@@ -104,7 +104,7 @@ def execute(
     io_hdr.sbp = sense
     io_hdr.timeout = 1800000
     io_hdr.flags = 0
-    io_hdr.mx_sb_len = len(sense)
+    io_hdr.mx_sb_len = 32  # we allocate it ourselves.
 
     if data_out is not None:
         data_out_len = len(data_out)


### PR DESCRIPTION
We allocate the buffer ourselves, so there's no reason to run `len()` on it
to get the length. And as it turns out, since we're using a pointer rather
than a view, this is using the _string_ length rather than the buffer
length.

This should correct issue #2. Tested using
python-scsi/examples/reportluns.py on a device that does not have LUNs.