### PR TITLE
Use setup-cfg-fmt to provide a more standardized setup.cfg.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,32 +5,27 @@
 [metadata]
 name = cython-sgio
 description = Cython-based wrapper for sending SCSI Generic I/O commands from Python.
-url = https://github.com/python-scsi/cython-sgio
-license_files =
-   AUTHORS
-   LICENSES/*
-long_description = file:README.md
+long_description = file: README.md
 long_description_content_type = text/markdown
+url = https://github.com/python-scsi/cython-sgio
 maintainer = Diego Elio Pettenò
 maintainer_email = flameeyes@flameeyes.com
+license = LGPL-2.1+
+license_files =
+    AUTHORS
+    LICENSES/*
 platforms =
     linux
-license = LGPL-2.1+
-keywords =
-    scsi
 classifiers =
-    Programming Language :: Python
-    Programming Language :: Python :: 3
     Development Status :: 4 - Beta
     License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+keywords =
+    scsi
 
 [options]
 packages = find:
-
-[options.package_data]
-* =
-    *.pyx
-    *.pxd
 
 [options.extras_require]
 dev =
@@ -40,6 +35,11 @@ dev =
     setuptools>=42
     setuptools_scm[toml]>=3.4
     wheel
+
+[options.package_data]
+* =
+    *.pyx
+    *.pxd
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
This maintains the E501 ignore reason _and_ the SPDX headers.