### PR TITLE
Optionally return any sense buffer we got from the device

### DIFF
--- a/src/linux_sgio.pyx
+++ b/src/linux_sgio.pyx
@@ -92,6 +92,7 @@ def execute(
         data_out,
         bytearray data_in,
         max_sense_data_length = 32,
+        return_sense_buffer=False
 ):
     """Execute a SCSI Generic ioctl on the provided file object.
 
@@ -179,7 +180,10 @@ def execute(
             else:
                 raise UnspecifiedError()
 
-        # Return the actual transfer written.
-        return io_hdr.resid
+        # Return the actual transfer written and any sense we got.
+        if return_sense_buffer:
+            return io_hdr.resid, bytes(sense[:io_hdr.sb_len_wr])
+        else:
+            return io_hdr.resid
     finally:
         free(sense)


### PR DESCRIPTION
Add a mechanism to optionally return the sense buffer to python-scsi.
This relates to requirement from pull request #107

Signed-off-by: Ronnie Sahlberg <ronniesahlberg@gmail.com>