### PR TITLE
chore: bump up github workflow deps

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,26 +4,26 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
--   repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+-   repo: https://github.com/PyCQA/isort
+    rev: 8.0.1
     hooks:
       - id: isort
         additional_dependencies:
           - toml
 -   repo: https://github.com/python/black
-    rev: 23.3.0
+    rev: 24.4.2
     hooks:
     - id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.3.0
     hooks:
     - id: flake8
 -   repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.2
+    rev: v4.0.3
     hooks:
     - id: reuse


### PR DESCRIPTION
- pre-commit.yml
  - pre-commit/action 2.0.0 to 3.0.1
- .pre-commit-config.yml
  - isort 5.12.0 to 8.0.1 and url update
  - black 23.3.0 to 24.4.2
  - flake8 6.0.0 to 7.3.0
  - reuse 1.1.2 to 4.0.3